### PR TITLE
D01 19627 polynomial

### DIFF
--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -22,8 +22,7 @@ from ..base import BaseEstimator, TransformerMixin
 from ..utils import check_array
 from ..utils.deprecation import deprecated
 from ..utils.extmath import row_norms
-from ..utils.extmath import (_incremental_mean_and_var,
-                             _incremental_weighted_mean_and_var)
+from ..utils.extmath import _incremental_mean_and_var
 from ..utils.sparsefuncs_fast import (inplace_csr_row_normalize_l1,
                                       inplace_csr_row_normalize_l2)
 from ..utils.sparsefuncs import (inplace_column_scale,
@@ -837,17 +836,11 @@ class StandardScaler(TransformerMixin, BaseEstimator):
                 self.mean_ = None
                 self.var_ = None
                 self.n_samples_seen_ += X.shape[0] - np.isnan(X).sum(axis=0)
-
-            elif sample_weight is not None:
-                self.mean_, self.var_, self.n_samples_seen_ = \
-                    _incremental_weighted_mean_and_var(X, sample_weight,
-                                                       self.mean_,
-                                                       self.var_,
-                                                       self.n_samples_seen_)
             else:
                 self.mean_, self.var_, self.n_samples_seen_ = \
                     _incremental_mean_and_var(X, self.mean_, self.var_,
-                                              self.n_samples_seen_)
+                                              self.n_samples_seen_,
+                                              sample_weight=sample_weight)
 
         # for backward-compatibility, reduce n_samples_seen_ to an integer
         # if the number of samples is the same for each feature (i.e. no

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1636,9 +1636,9 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
     <sphx_glr_auto_examples_linear_model_plot_polynomial_interpolation.py>`
     """
     @_deprecate_positional_args
-    def __init__(self, max_degree=2, *, interaction_only=False, include_bias=True,
-                 order='C', min_degree=0, degree=0):
-        self.max_degree = degree or max_degree # lazy evaluation to handle deprecaition
+    def __init__(self, max_degree=None, *, interaction_only=False, include_bias=True,
+                 order='C', min_degree=0, degree=2):
+        self.max_degree = max_degree or degree # lazy evaluation to handle deprecaition
         self.min_degree = min_degree or int(not include_bias) # lazy evaluation to handle deprecaition
         self.interaction_only = interaction_only
         self.include_bias = include_bias

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1637,6 +1637,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
         self.order = order
 
     @staticmethod
+    @_deprecate_positional_args
     def _combinations(n_features, degree, interaction_only, include_bias):
         comb = (combinations if interaction_only else combinations_w_r)
         start = int(not include_bias)

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1865,9 +1865,9 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
 
                     new_index.append(current_col)
                     index = new_index
-        # omit unwanted dynamic programming columns that were used for optimized calculation
-        if self.min_degree >= 2:
-            XP = XP[:, XP_width-self.n_output_features_:]
+                # omit unwanted dynamic programming columns that were used for optimized calculation
+                if self.min_degree >= 2:
+                    XP = XP[:, XP_width-self.n_output_features_:]
         return XP
 
 

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -291,7 +291,7 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
 
-@pytest.mark.parametrize(['deg', 'interaction_only', 'min'],
+@pytest.mark.parametrize(['deg', 'interaction_only', 'min_deg'],
                          [(2, True, 0),
                          (3, True, 1),
                          (3, True, 2),

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -156,6 +156,18 @@ def test_polynomial_features_max_degree_instead_of_degree():
     res = poly.fit_transform(X)
     assert_array_almost_equal(res, [[1., 2., 3., 4., 6., 8., 12.]])
 
+def test_polynomial_features_min_degree_2_max_degree_bigger():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(max_degree=3, min_degree=2, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[1., 2., 3., 4., 6., 8., 12., 24.]])
+def test_polynomial_features_min_degree_2_max_degree_bigger_all_combinations():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(max_degree=3, min_degree=2, interaction_only=False)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[ 4.,  6.,  8.,  9., 12., 16.,  8., 12., 16., 18., 24., 32., 27.,
+        36., 48., 64.]])
+
 def test_polynomial_feature_names():
     X = np.arange(30).reshape(10, 3)
     poly = PolynomialFeatures(degree=2, include_bias=True).fit(X)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -126,6 +126,35 @@ def test_polynomial_features():
     assert interact.powers_.shape == (interact.n_output_features_,
                                       interact.n_input_features_)
 
+def test_polynomial_features_min_degree_equals_max_degree():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(min_degree=2, max_degree=2, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[6., 8., 12.]])
+
+def test_polynomial_features_include_bias_overrides_min_degree():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(include_bias=False, min_degree=0, max_degree=2, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[2., 3., 4., 6., 8., 12.]])
+
+def test_polynomial_features_min_degree_overrides_include_bias():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(include_bias=False, min_degree=2, max_degree=2, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[6., 8., 12.]])
+
+def test_polynomial_features_min_degree_greater_than_max_degree():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(min_degree=4, max_degree=2, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[]])
+
+def test_polynomial_features_max_degree_instead_of_degree():
+    X = [[2, 3, 4]]
+    poly = PolynomialFeatures(max_degree=2, degree=6, interaction_only=True)
+    res = poly.fit_transform(X)
+    assert_array_almost_equal(res, [[1., 2., 3., 4., 6., 8., 12.]])
 
 def test_polynomial_feature_names():
     X = np.arange(30).reshape(10, 3)

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -160,12 +160,12 @@ def test_polynomial_features_min_degree_2_max_degree_bigger():
     X = [[2, 3, 4]]
     poly = PolynomialFeatures(max_degree=3, min_degree=2, interaction_only=True)
     res = poly.fit_transform(X)
-    assert_array_almost_equal(res, [[1., 2., 3., 4., 6., 8., 12., 24.]])
+    assert_array_almost_equal(res, [[6., 8., 12., 24.]])
 def test_polynomial_features_min_degree_2_max_degree_bigger_all_combinations():
     X = [[2, 3, 4]]
     poly = PolynomialFeatures(max_degree=3, min_degree=2, interaction_only=False)
     res = poly.fit_transform(X)
-    assert_array_almost_equal(res, [[ 4.,  6.,  8.,  9., 12., 16.,  8., 12., 16., 18., 24., 32., 27.,
+    assert_array_almost_equal(res, [[4.,  6.,  8.,  9., 12., 16.,  8., 12., 16., 18., 24., 32., 27.,
         36., 48., 64.]])
 
 def test_polynomial_feature_names():

--- a/sklearn/preprocessing/tests/test_data.py
+++ b/sklearn/preprocessing/tests/test_data.py
@@ -291,6 +291,25 @@ def test_polynomial_features_csr_X_dim_edges(deg, dim, interaction_only):
     assert_array_almost_equal(Xt_csr.A, Xt_dense)
 
 
+@pytest.mark.parametrize(['deg', 'interaction_only', 'min'],
+                         [(2, True, 0),
+                         (3, True, 1),
+                         (3, True, 2),
+                         (3, False, 3)])
+def test_polynomial_features_min_degree(deg, interaction_only, min_deg):
+    X_csr = sparse_random(1000, deg, 0.5, random_state=0).tocsr()
+    X = X_csr.toarray()
+
+    est = PolynomialFeatures(deg, interaction_only=interaction_only, min_degree=min_deg)
+    Xt_csr = est.fit_transform(X_csr)
+    Xt_dense = est.fit_transform(X)
+
+    assert isinstance(Xt_csr, sparse.csr_matrix)
+    assert Xt_csr.dtype == Xt_dense.dtype
+    assert_array_almost_equal(Xt_csr.A, Xt_dense)
+
+
+
 def test_raises_value_error_if_sample_weights_greater_than_1d():
     # Sample weights must be either scalar or 1D
 


### PR DESCRIPTION
Added functionality for a `min_degree` parameter to be passed into the `sklearn.preprocessing.PolynomialFeatures` contructor, which allows you to specify the minimal degree of the combinations produced.

This PR adds in the arguments:
`max_degree`: Deprecates the `degree` argument with no change in functionality
`min_degree`: Deprecates the `include_bias` argument (`min_degree = 0/1` is equivalent to `include_bias = True/False` respectively)

The changes to the `PolynomialFeatures` are fully backwards compatible as well!

Unit tests were added to `preprocessing/test_data.py`. 