### PR TITLE
D01 18186 multiprocessing

### DIFF
--- a/sklearn/impute/_knn.py
+++ b/sklearn/impute/_knn.py
@@ -3,6 +3,8 @@
 # License: BSD 3 clause
 
 import numpy as np
+from multiprocessing import cpu_count
+from joblib import Parallel, delayed
 
 from ._base import _BaseImputer
 from ..utils.validation import FLOAT_DTYPES
@@ -236,55 +238,61 @@ class KNNImputer(_BaseImputer):
         dist_idx_map = np.zeros(X.shape[0], dtype=int)
         dist_idx_map[row_missing_idx] = np.arange(row_missing_idx.shape[0])
 
+
+        def process_chunk_col(dist_chunk, start, row_missing_chunk, col):
+            if not valid_mask[col]:
+                # column was all missing during training
+                return
+
+            col_mask = mask[row_missing_chunk, col]
+            if not np.any(col_mask):
+                # column has no missing values
+                return
+
+            potential_donors_idx, = np.nonzero(non_missing_fix_X[:, col])
+
+            # receivers_idx are indices in X
+            receivers_idx = row_missing_chunk[np.flatnonzero(col_mask)]
+
+            # distances for samples that needed imputation for column
+            dist_subset = (dist_chunk[dist_idx_map[receivers_idx] - start]
+                            [:, potential_donors_idx])
+
+            # receivers with all nan distances impute with mean
+            all_nan_dist_mask = np.isnan(dist_subset).all(axis=1)
+            all_nan_receivers_idx = receivers_idx[all_nan_dist_mask]
+
+            if all_nan_receivers_idx.size:
+                col_mean = np.ma.array(self._fit_X[:, col],
+                                        mask=mask_fit_X[:, col]).mean()
+                X[all_nan_receivers_idx, col] = col_mean
+
+                if len(all_nan_receivers_idx) == len(receivers_idx):
+                    # all receivers imputed with mean
+                    return
+
+                # receivers with at least one defined distance
+                receivers_idx = receivers_idx[~all_nan_dist_mask]
+                dist_subset = (dist_chunk[dist_idx_map[receivers_idx]
+                                          - start]
+                                [:, potential_donors_idx])
+
+            n_neighbors = min(self.n_neighbors, len(potential_donors_idx))
+            value = self._calc_impute(
+                dist_subset,
+                n_neighbors,
+                self._fit_X[potential_donors_idx, col],
+                mask_fit_X[potential_donors_idx, col])
+            X[receivers_idx, col] = value
+
         def process_chunk(dist_chunk, start):
             row_missing_chunk = row_missing_idx[start:start + len(dist_chunk)]
 
             # Find and impute missing by column
-            for col in range(X.shape[1]):
-                if not valid_mask[col]:
-                    # column was all missing during training
-                    continue
-
-                col_mask = mask[row_missing_chunk, col]
-                if not np.any(col_mask):
-                    # column has no missing values
-                    continue
-
-                potential_donors_idx, = np.nonzero(non_missing_fix_X[:, col])
-
-                # receivers_idx are indices in X
-                receivers_idx = row_missing_chunk[np.flatnonzero(col_mask)]
-
-                # distances for samples that needed imputation for column
-                dist_subset = (dist_chunk[dist_idx_map[receivers_idx] - start]
-                               [:, potential_donors_idx])
-
-                # receivers with all nan distances impute with mean
-                all_nan_dist_mask = np.isnan(dist_subset).all(axis=1)
-                all_nan_receivers_idx = receivers_idx[all_nan_dist_mask]
-
-                if all_nan_receivers_idx.size:
-                    col_mean = np.ma.array(self._fit_X[:, col],
-                                           mask=mask_fit_X[:, col]).mean()
-                    X[all_nan_receivers_idx, col] = col_mean
-
-                    if len(all_nan_receivers_idx) == len(receivers_idx):
-                        # all receivers imputed with mean
-                        continue
-
-                    # receivers with at least one defined distance
-                    receivers_idx = receivers_idx[~all_nan_dist_mask]
-                    dist_subset = (dist_chunk[dist_idx_map[receivers_idx]
-                                              - start]
-                                   [:, potential_donors_idx])
-
-                n_neighbors = min(self.n_neighbors, len(potential_donors_idx))
-                value = self._calc_impute(
-                    dist_subset,
-                    n_neighbors,
-                    self._fit_X[potential_donors_idx, col],
-                    mask_fit_X[potential_donors_idx, col])
-                X[receivers_idx, col] = value
+            Parallel(n_jobs=cpu_count(), backend='threading')(delayed(process_chunk_col)(dist_chunk, start, row_missing_chunk, col) for col in range(X.shape[1]))
+            # for col in range(X.shape[1]):
+            #     process_chunk_col(dist_chunk, start, row_missing_chunk, col)
+                
 
         # process in fixed-memory chunks
         gen = pairwise_distances_chunked(

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+from sklearn.impute import KNNImputer
+import time
+
+
+
+def large_random_matrix(x, y):
+    np.random.seed(1)
+
+    X = np.random.random([x, y])
+    X = pd.DataFrame(X).mask(X < 0.1)
+
+    imputer = KNNImputer(n_neighbors=5)
+
+    imputer.fit_transform(X)
+
+
+def test_1K_by_100():
+    # The original implementation takes over 0.42 seconds
+    start = time.time()
+    large_random_matrix(1000, 100)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0.1
+
+
+def test_2K_by_500():
+    # The original implementation takes over 8.05 seconds
+    start = time.time()
+    large_random_matrix(2000, 500)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 5
+
+
+def test_K_by_K():
+    # The original implementation takes over 33.48 seconds
+    start = time.time()
+    large_random_matrix(1000, 5000)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0
+
+
+# def test_3K_by_1K():
+#     # The original implementation takes over 33.48 seconds
+#     start = time.time()
+#     large_random_matrix(3000, 1000)
+#     end = time.time()
+#
+#     print("\nTime: ", end-start)
+#
+#     assert end-start > 30
+#
+#
+# def test_10K_by_100():
+#     # The original implementation takes over 49.96 seconds
+#     start = time.time()
+#     large_random_matrix(10000, 100)
+#     end = time.time()
+#
+#     print("\nTime: ", end-start)
+#
+#     assert end-start > 45

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -8,9 +8,9 @@ import pytest
 ##################### THIS TEST SUITE WILL TAKE APPROXIMATELY 15 MINUTES, BUT VARIES BY MACHINE ############################
 
 # Initialise constants
-epsilon = 0.5
+epsilon = 0.75 # Seconds of breathing room for smaller sized n tests
 perc = [0.1,0.5,0.9] # We want to test a varying amount of missing values to impute, each of these represent the precrentage of missing values in X
-small_n = [100,300,500]
+small_n = [5,300,500]
 large_n = [1000,3000,5000]
 
 # generate random array of size x by y with (p*100)% missing values

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -4,6 +4,8 @@ from sklearn.impute import KNNImputer
 import time
 
 
+# Total Original Time:  97.91s
+# Total new Time:       48.07s
 
 def large_random_matrix(x, y):
     np.random.seed(1)
@@ -17,31 +19,10 @@ def large_random_matrix(x, y):
 
 
 def test_1K_by_100():
-    # The original implementation takes over 0.42 seconds
+    # The original implementation takes 0.4349205493927002 seconds
+    # The new implementation takes      0.3454127311706543 seconds
     start = time.time()
     large_random_matrix(1000, 100)
-    end = time.time()
-
-    print("\nTime: ", end-start)
-
-    assert end-start > 0.1
-
-
-def test_2K_by_500():
-    # The original implementation takes over 8.05 seconds
-    start = time.time()
-    large_random_matrix(2000, 500)
-    end = time.time()
-
-    print("\nTime: ", end-start)
-
-    assert end-start > 5
-
-
-def test_K_by_K():
-    # The original implementation takes over 33.48 seconds
-    start = time.time()
-    large_random_matrix(1000, 5000)
     end = time.time()
 
     print("\nTime: ", end-start)
@@ -49,23 +30,60 @@ def test_K_by_K():
     assert end-start > 0
 
 
-# def test_3K_by_1K():
-#     # The original implementation takes over 33.48 seconds
-#     start = time.time()
-#     large_random_matrix(3000, 1000)
-#     end = time.time()
-#
-#     print("\nTime: ", end-start)
-#
-#     assert end-start > 30
-#
-#
-# def test_10K_by_100():
-#     # The original implementation takes over 49.96 seconds
-#     start = time.time()
-#     large_random_matrix(10000, 100)
-#     end = time.time()
-#
-#     print("\nTime: ", end-start)
-#
-#     assert end-start > 45
+def test_2K_by_500():
+    # The original implementation takes 6.568829774856567 seconds
+    # The new implementation takes      3.880154848098755 seconds
+    start = time.time()
+    large_random_matrix(2000, 500)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0
+
+
+def test_1K_by_5K():
+    # The original implementation takes 17.162961959838867 seconds
+    # The new implementation takes      12.638985633850098 seconds
+    start = time.time()
+    large_random_matrix(1000, 5000)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end - start > 0
+    
+def test_10K_by_4():
+    # The original implementation takes 2.436619281768799 seconds
+    # The new implementation takes      1.8823344707489014 seconds
+    start = time.time()
+    large_random_matrix(10000, 4)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0
+
+
+def test_3K_by_1K():
+    # The original implementation takes 28.86723804473877 seconds
+    # The new implementation takes      18.428542137145996 seconds
+    start = time.time()
+    large_random_matrix(3000, 1000)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0
+
+
+def test_10K_by_100():
+    # The original implementation takes 40.690518856048584 seconds
+    # The new implementation takes      33.974459171295166 seconds
+    start = time.time()
+    large_random_matrix(10000, 100)
+    end = time.time()
+
+    print("\nTime: ", end-start)
+
+    assert end-start > 0

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -5,21 +5,22 @@ import time
 import profile
 import pytest
 
+##################### THIS TEST SUITE WILL TAKE APPROXIMATELY 15 MINUTES, BUT VARIES BY MACHINE ############################
 
-# Total Original Time:  97.91s
-# Total new Time:       48.07s
-
-perc = [0,0.1,0.5,0.9,1]
+# Initialise constants
+epsilon = 0.5
+perc = [0.1,0.5,0.9] # We want to test a varying amount of missing values to impute, each of these represent the precrentage of missing values in X
 small_n = [100,300,500]
 large_n = [1000,3000,5000]
 
+# generate random array of size x by y with (p*100)% missing values
 def gen_matrix(x, y, p):
     np.random.seed(1)
     X = np.random.random([x, y])
     X = pd.DataFrame(X).mask(X <= p)
     return X
 
-
+# Run (simulated) old time or new time, return start and end times
 def run_test(X, old=False):
     start = time.time()
     if (old):
@@ -32,11 +33,13 @@ def run_test(X, old=False):
     return start,end
 
 def relative_assert(new, old):
-    assert pytest.approx(new).__lt__(pytest.approx(old, abs=1))
+    # Since smaller times will yield more sporatic results, an amount of seconds of amount epsilon are accounted for
+    assert ((new == pytest.approx(old, abs=epsilon)) or (new < old))
 
 def output_res(old_end,old_start,end,start):
     print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% improved")
 
+# Test arrays of size 1 by a small n with varying missing values
 @pytest.mark.parametrize("n,p",[(n, p) for p in perc for n in small_n])
 def test_time_1_by_n(n,p):
     X = gen_matrix(1, n, p)
@@ -48,6 +51,7 @@ def test_time_1_by_n(n,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of size 1 by a large n with varying missing values
 @pytest.mark.parametrize("N,p",[(N, p) for p in perc for N in large_n])
 def test_time_1_by_N(N,p):
     X = gen_matrix(1, N, p)
@@ -59,6 +63,7 @@ def test_time_1_by_N(N,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of a small n by 1 with varying missing values
 @pytest.mark.parametrize("n,p",[(n, p) for p in perc for n in small_n])
 def test_time_n_by_1(n,p):
     X = gen_matrix(n, 1, p)
@@ -70,6 +75,7 @@ def test_time_n_by_1(n,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of a large n by 1 with varying missing values
 @pytest.mark.parametrize("N,p",[(N, p) for p in perc for N in large_n])
 def test_time_N_by_1(N,p):
     X = gen_matrix(N, 1, p)
@@ -81,6 +87,7 @@ def test_time_N_by_1(N,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of a small n by a small n with varying missing values
 @pytest.mark.parametrize("n1,n2,p",[(n1,n2,p) for p in perc for n1 in small_n for n2 in small_n])
 def test_time_n_by_n(n1,n2,p):
     X = gen_matrix(n1, n2, p)
@@ -92,6 +99,7 @@ def test_time_n_by_n(n1,n2,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of a small n by a large n with varying missing values
 @pytest.mark.parametrize("n,N,p",[(n,N,p) for p in perc for n in small_n for N in large_n])
 def test_time_n_by_N(n,N,p):
     X = gen_matrix(n, N, p)
@@ -103,6 +111,9 @@ def test_time_n_by_N(n,N,p):
 
     relative_assert(end-start, old_end-old_start)
 
+# Test arrays of a large n by a small n with varying missing values
+### This is the most important test case since it is the most likely scenario for usage
+### (More likely to be testing a large number of features)
 @pytest.mark.parametrize("N,n,p",[(N,n,p) for p in perc for n in small_n for N in large_n])
 def test_time_N_by_n(N,n,p):
     X = gen_matrix(N, n, p)
@@ -114,13 +125,15 @@ def test_time_N_by_n(N,n,p):
 
     relative_assert(end-start, old_end-old_start)
 
-# @pytest.mark.parametrize("N1,N2,p",[(N1,N2,p) for p in perc for n in large_n for N in large_n])
-# def test_time_N_by_N(N1, N2):
-#     X = gen_matrix(N1, N2, p)
+# Test arrays of a large n by a large n with varying missing values
+# (This takes a VERY long time to run, since they are more often called individually)
+## @pytest.mark.parametrize("N1,N2,p",[(N1,N2,p) for p in perc for N1 in large_n for N2 in large_n])
+## def test_time_N_by_N(N1, N2, p):
+##     X = gen_matrix(N1, N2, p)
 
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
+##     start, end = run_test(X)
+##     old_start, old_end = run_test(X, old=True)
 
-#     output_res(old_end,old_start,end,start)
+##     output_res(old_end,old_start,end,start)
 
-#     relative_assert(end-start, old_end-old_start)
+##     relative_assert(end-start, old_end-old_start)

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -12,7 +12,7 @@ import pytest
 def gen_matrix(x, y, p=0.1):
     np.random.seed(1)
     X = np.random.random([x, y])
-    X = pd.DataFrame(X).mask(X < 0.1)
+    X = pd.DataFrame(X).mask(X < p)
     return X
 
 
@@ -27,64 +27,66 @@ def run_test(X, old=False):
 
     return start,end
 
+def relative_assert(new, old):
+    assert pytest.approx(new).__lt__(pytest.approx(old, abs=1))
+
 def output_res(old_end,old_start,end,start):
     print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% improved")
 
-
-# @pytest.mark.parametrize("n",[100,200,300,400,500])
-# def test_1_by_n(n):
-#     X = gen_matrix(1, n)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
-
-# @pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
-# def test_1_by_N(N):
-#     X = gen_matrix(1, N)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
-
-# @pytest.mark.parametrize("n",[100,200,300,400,500])
-# def test_n_by_1(n):
-#     X = gen_matrix(n, 1)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
-
-# @pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
-# def test_N_by_1(N):
-#     X = gen_matrix(N, 1)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
-
-@pytest.mark.parametrize("n1,n2",[(n1,n2) for n1 in [100,200,300,400,500] for n2 in [100,200,300,400,500]])
-def test_n_by_n(n1,n2):
-    X = gen_matrix(n1, n2)
+@pytest.mark.parametrize("n,p",[(n, p) for p in [0,0.1,0.5,0.9,1] for n in [100,200,300,400,500]])
+def test_1_by_n(n,p):
+    X = gen_matrix(1, n, p)
 
     start, end = run_test(X)
     old_start, old_end = run_test(X, old=True)
 
     output_res(old_end,old_start,end,start)
 
-    assert (end-start) < (old_end-old_start)
+    relative_assert(end-start, old_end-old_start)
+
+@pytest.mark.parametrize("N,p",[(N, p) for p in [0,0.1,0.5,0.9,1] for N in [1000,2000,3000,4000,5000,10000]])
+def test_1_by_N(N,p):
+    X = gen_matrix(1, N, p)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
+
+@pytest.mark.parametrize("n",[100,200,300,400,500])
+def test_n_by_1(n):
+    X = gen_matrix(n, 1)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
+
+@pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
+def test_N_by_1(N):
+    X = gen_matrix(N, 1)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
+
+@pytest.mark.parametrize("n1,n2,p",[(n1,n2,p) for p in [0,0.1,0.5,0.9,1] for n1 in [100,200,300,400,500] for n2 in [100,200,300,400,500]])
+def test_n_by_n(n1,n2,p):
+    X = gen_matrix(n1, n2, p)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
 
 # @pytest.mark.parametrize("n,N",[(n,N) for n in [100,200,300,400,500] for N in [1000,2000,3000,4000,5000]])
 # def test_n_by_N(n,N):

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -9,10 +9,14 @@ import pytest
 # Total Original Time:  97.91s
 # Total new Time:       48.07s
 
-def gen_matrix(x, y, p=0.1):
+perc = [0,0.1,0.5,0.9,1]
+small_n = [100,300,500]
+large_n = [1000,3000,5000]
+
+def gen_matrix(x, y, p):
     np.random.seed(1)
     X = np.random.random([x, y])
-    X = pd.DataFrame(X).mask(X < p)
+    X = pd.DataFrame(X).mask(X <= p)
     return X
 
 
@@ -33,8 +37,8 @@ def relative_assert(new, old):
 def output_res(old_end,old_start,end,start):
     print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% improved")
 
-@pytest.mark.parametrize("n,p",[(n, p) for p in [0,0.1,0.5,0.9,1] for n in [100,200,300,400,500]])
-def test_1_by_n(n,p):
+@pytest.mark.parametrize("n,p",[(n, p) for p in perc for n in small_n])
+def test_time_1_by_n(n,p):
     X = gen_matrix(1, n, p)
 
     start, end = run_test(X)
@@ -44,8 +48,8 @@ def test_1_by_n(n,p):
 
     relative_assert(end-start, old_end-old_start)
 
-@pytest.mark.parametrize("N,p",[(N, p) for p in [0,0.1,0.5,0.9,1] for N in [1000,2000,3000,4000,5000,10000]])
-def test_1_by_N(N,p):
+@pytest.mark.parametrize("N,p",[(N, p) for p in perc for N in large_n])
+def test_time_1_by_N(N,p):
     X = gen_matrix(1, N, p)
 
     start, end = run_test(X)
@@ -55,9 +59,9 @@ def test_1_by_N(N,p):
 
     relative_assert(end-start, old_end-old_start)
 
-@pytest.mark.parametrize("n",[100,200,300,400,500])
-def test_n_by_1(n):
-    X = gen_matrix(n, 1)
+@pytest.mark.parametrize("n,p",[(n, p) for p in perc for n in small_n])
+def test_time_n_by_1(n,p):
+    X = gen_matrix(n, 1, p)
 
     start, end = run_test(X)
     old_start, old_end = run_test(X, old=True)
@@ -66,9 +70,9 @@ def test_n_by_1(n):
 
     relative_assert(end-start, old_end-old_start)
 
-@pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
-def test_N_by_1(N):
-    X = gen_matrix(N, 1)
+@pytest.mark.parametrize("N,p",[(N, p) for p in perc for N in large_n])
+def test_time_N_by_1(N,p):
+    X = gen_matrix(N, 1, p)
 
     start, end = run_test(X)
     old_start, old_end = run_test(X, old=True)
@@ -77,8 +81,8 @@ def test_N_by_1(N):
 
     relative_assert(end-start, old_end-old_start)
 
-@pytest.mark.parametrize("n1,n2,p",[(n1,n2,p) for p in [0,0.1,0.5,0.9,1] for n1 in [100,200,300,400,500] for n2 in [100,200,300,400,500]])
-def test_n_by_n(n1,n2,p):
+@pytest.mark.parametrize("n1,n2,p",[(n1,n2,p) for p in perc for n1 in small_n for n2 in small_n])
+def test_time_n_by_n(n1,n2,p):
     X = gen_matrix(n1, n2, p)
 
     start, end = run_test(X)
@@ -88,34 +92,35 @@ def test_n_by_n(n1,n2,p):
 
     relative_assert(end-start, old_end-old_start)
 
-# @pytest.mark.parametrize("n,N",[(n,N) for n in [100,200,300,400,500] for N in [1000,2000,3000,4000,5000]])
-# def test_n_by_N(n,N):
-#     X = gen_matrix(n, N)
+@pytest.mark.parametrize("n,N,p",[(n,N,p) for p in perc for n in small_n for N in large_n])
+def test_time_n_by_N(n,N,p):
+    X = gen_matrix(n, N, p)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
+
+@pytest.mark.parametrize("N,n,p",[(N,n,p) for p in perc for n in small_n for N in large_n])
+def test_time_N_by_n(N,n,p):
+    X = gen_matrix(N, n, p)
+
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, old=True)
+
+    output_res(old_end,old_start,end,start)
+
+    relative_assert(end-start, old_end-old_start)
+
+# @pytest.mark.parametrize("N1,N2,p",[(N1,N2,p) for p in perc for n in large_n for N in large_n])
+# def test_time_N_by_N(N1, N2):
+#     X = gen_matrix(N1, N2, p)
 
 #     start, end = run_test(X)
 #     old_start, old_end = run_test(X, old=True)
 
 #     output_res(old_end,old_start,end,start)
 
-#     assert (end-start) < (old_end-old_start)
-
-# @pytest.mark.parametrize("N,n",[(N,n) for n in [100,200,300,400,500] for N in [1000,2000,3000,4000,5000]])
-# def test_N_by_n(N,n):
-#     X = gen_matrix(N, n)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
-
-# def test_N_by_n():
-#     X = gen_matrix(10000, 100)
-
-#     start, end = run_test(X)
-#     old_start, old_end = run_test(X, old=True)
-
-#     output_res(old_end,old_start,end,start)
-
-#     assert (end-start) < (old_end-old_start)
+#     relative_assert(end-start, old_end-old_start)

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -3,6 +3,7 @@ import pandas as pd
 from sklearn.impute import KNNImputer
 import time
 import profile
+import pytest
 
 
 # Total Original Time:  97.91s
@@ -26,68 +27,93 @@ def run_test(X, old=False):
 
     return start,end
 
+def output_res(old_end,old_start,end,start):
+    print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% improved")
 
-def test_1K_by_100():
-    X = gen_matrix(1000,100)
+
+# @pytest.mark.parametrize("n",[100,200,300,400,500])
+# def test_1_by_n(n):
+#     X = gen_matrix(1, n)
+
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
+
+#     output_res(old_end,old_start,end,start)
+
+#     assert (end-start) < (old_end-old_start)
+
+# @pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
+# def test_1_by_N(N):
+#     X = gen_matrix(1, N)
+
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
+
+#     output_res(old_end,old_start,end,start)
+
+#     assert (end-start) < (old_end-old_start)
+
+# @pytest.mark.parametrize("n",[100,200,300,400,500])
+# def test_n_by_1(n):
+#     X = gen_matrix(n, 1)
+
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
+
+#     output_res(old_end,old_start,end,start)
+
+#     assert (end-start) < (old_end-old_start)
+
+# @pytest.mark.parametrize("N",[1000,2000,3000,4000,5000,10000])
+# def test_N_by_1(N):
+#     X = gen_matrix(N, 1)
+
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
+
+#     output_res(old_end,old_start,end,start)
+
+#     assert (end-start) < (old_end-old_start)
+
+@pytest.mark.parametrize("n1,n2",[(n1,n2) for n1 in [100,200,300,400,500] for n2 in [100,200,300,400,500]])
+def test_n_by_n(n1,n2):
+    X = gen_matrix(n1, n2)
 
     start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
+    old_start, old_end = run_test(X, old=True)
 
-    print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+    output_res(old_end,old_start,end,start)
 
     assert (end-start) < (old_end-old_start)
 
+# @pytest.mark.parametrize("n,N",[(n,N) for n in [100,200,300,400,500] for N in [1000,2000,3000,4000,5000]])
+# def test_n_by_N(n,N):
+#     X = gen_matrix(n, N)
 
-def test_2K_by_500():
-    X = gen_matrix(2000, 500)
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
 
-    start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
+#     output_res(old_end,old_start,end,start)
 
-    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+#     assert (end-start) < (old_end-old_start)
 
-    assert (end-start) < (old_end-old_start)
+# @pytest.mark.parametrize("N,n",[(N,n) for n in [100,200,300,400,500] for N in [1000,2000,3000,4000,5000]])
+# def test_N_by_n(N,n):
+#     X = gen_matrix(N, n)
 
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
 
-def test_1K_by_5K():
-    X = gen_matrix(1000, 5000)
+#     output_res(old_end,old_start,end,start)
 
-    start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
+#     assert (end-start) < (old_end-old_start)
 
-    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+# def test_N_by_n():
+#     X = gen_matrix(10000, 100)
 
-    assert (end-start) < (old_end-old_start)
+#     start, end = run_test(X)
+#     old_start, old_end = run_test(X, old=True)
 
+#     output_res(old_end,old_start,end,start)
 
-def test_10K_by_4():
-    X = gen_matrix(10000, 4)
-
-    start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
-
-    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
-
-    assert (end-start) < (old_end-old_start)
-
-
-def test_3K_by_1K():
-    X = gen_matrix(3000, 1000)
-
-    start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
-
-    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
-
-    assert (end-start) < (old_end-old_start)
-
-
-def test_10K_by_100():
-    X = gen_matrix(10000, 100)
-
-    start, end = run_test(X)
-    old_start, old_end = run_test(X, True)
-
-    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
-
-    assert (end-start) < (old_end-old_start)
+#     assert (end-start) < (old_end-old_start)

--- a/sklearn/impute/tests/test_time.py
+++ b/sklearn/impute/tests/test_time.py
@@ -2,88 +2,92 @@ import numpy as np
 import pandas as pd
 from sklearn.impute import KNNImputer
 import time
+import profile
 
 
 # Total Original Time:  97.91s
 # Total new Time:       48.07s
 
-def large_random_matrix(x, y):
+def gen_matrix(x, y, p=0.1):
     np.random.seed(1)
-
     X = np.random.random([x, y])
     X = pd.DataFrame(X).mask(X < 0.1)
+    return X
 
-    imputer = KNNImputer(n_neighbors=5)
 
+def run_test(X, old=False):
+    start = time.time()
+    if (old):
+        imputer = KNNImputer(n_neighbors=5, n_jobs=1)
+    else:
+        imputer = KNNImputer(n_neighbors=5)
     imputer.fit_transform(X)
+    end = time.time()
+
+    return start,end
 
 
 def test_1K_by_100():
-    # The original implementation takes 0.4349205493927002 seconds
-    # The new implementation takes      0.3454127311706543 seconds
-    start = time.time()
-    large_random_matrix(1000, 100)
-    end = time.time()
+    X = gen_matrix(1000,100)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end-start > 0
+    print("\nOld time:", round((old_end-old_start),4) ,", New time:", round((end-start),4),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)
 
 
 def test_2K_by_500():
-    # The original implementation takes 6.568829774856567 seconds
-    # The new implementation takes      3.880154848098755 seconds
-    start = time.time()
-    large_random_matrix(2000, 500)
-    end = time.time()
+    X = gen_matrix(2000, 500)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end-start > 0
+    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)
 
 
 def test_1K_by_5K():
-    # The original implementation takes 17.162961959838867 seconds
-    # The new implementation takes      12.638985633850098 seconds
-    start = time.time()
-    large_random_matrix(1000, 5000)
-    end = time.time()
+    X = gen_matrix(1000, 5000)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end - start > 0
-    
+    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)
+
+
 def test_10K_by_4():
-    # The original implementation takes 2.436619281768799 seconds
-    # The new implementation takes      1.8823344707489014 seconds
-    start = time.time()
-    large_random_matrix(10000, 4)
-    end = time.time()
+    X = gen_matrix(10000, 4)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end-start > 0
+    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)
 
 
 def test_3K_by_1K():
-    # The original implementation takes 28.86723804473877 seconds
-    # The new implementation takes      18.428542137145996 seconds
-    start = time.time()
-    large_random_matrix(3000, 1000)
-    end = time.time()
+    X = gen_matrix(3000, 1000)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end-start > 0
+    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)
 
 
 def test_10K_by_100():
-    # The original implementation takes 40.690518856048584 seconds
-    # The new implementation takes      33.974459171295166 seconds
-    start = time.time()
-    large_random_matrix(10000, 100)
-    end = time.time()
+    X = gen_matrix(10000, 100)
 
-    print("\nTime: ", end-start)
+    start, end = run_test(X)
+    old_start, old_end = run_test(X, True)
 
-    assert end-start > 0
+    print("\nOld time:", round((old_end-old_start),3),", New time:", round((end-start),3),",", str(round(((old_end-old_start)/(end-start) - 1)*100, 2))+"% increase")
+
+    assert (end-start) < (old_end-old_start)

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -18,6 +18,7 @@ from scipy.spatial import distance
 from scipy.sparse import csr_matrix
 from scipy.sparse import issparse
 from joblib import Parallel, effective_n_jobs
+from multiprocessing import cpu_count
 
 from ..utils.validation import _num_samples
 from ..utils.validation import check_non_negative
@@ -1644,7 +1645,7 @@ def pairwise_distances_chunked(X, Y=None, *, reduce_func=None,
     params = _precompute_metric_params(X, Y, metric=metric, **kwds)
     kwds.update(**params)
 
-    for sl in slices:
+    def _process_slice(sl, reduce_func):
         if sl.start == 0 and sl.stop == n_samples_X:
             X_chunk = X  # enable optimised paths for X is Y
         else:
@@ -1661,8 +1662,12 @@ def pairwise_distances_chunked(X, Y=None, *, reduce_func=None,
             chunk_size = D_chunk.shape[0]
             D_chunk = reduce_func(D_chunk, sl.start)
             _check_chunk_size(D_chunk, chunk_size)
-        yield D_chunk
+        return D_chunk
 
+    generator = (delayed(_process_slice)(sl, reduce_func) for sl in slices)
+    par_res=Parallel(n_jobs, backend='threading')(generator)
+    for res in par_res:
+        yield res
 
 @_deprecate_positional_args
 def pairwise_distances(X, Y=None, metric="euclidean", *, n_jobs=None,

--- a/sklearn/metrics/pairwise.py
+++ b/sklearn/metrics/pairwise.py
@@ -1664,10 +1664,14 @@ def pairwise_distances_chunked(X, Y=None, *, reduce_func=None,
             _check_chunk_size(D_chunk, chunk_size)
         return D_chunk
 
-    generator = (delayed(_process_slice)(sl, reduce_func) for sl in slices)
-    par_res=Parallel(n_jobs, backend='threading')(generator)
-    for res in par_res:
-        yield res
+    if effective_n_jobs(n_jobs) > 1:
+        generator = (delayed(_process_slice)(sl, reduce_func) for sl in slices)
+        par_res=Parallel(n_jobs, backend='threading')(generator)
+        for res in par_res:
+            yield res
+    else:
+        for sl in slices:
+            yield _process_slice(sl, reduce_func)
 
 @_deprecate_positional_args
 def pairwise_distances(X, Y=None, metric="euclidean", *, n_jobs=None,

--- a/sklearn/preprocessing/_data.py
+++ b/sklearn/preprocessing/_data.py
@@ -1643,6 +1643,7 @@ class PolynomialFeatures(TransformerMixin, BaseEstimator):
         self.interaction_only = interaction_only
         self.include_bias = include_bias
         self.order = order
+        self.degree = max_degree or degree # lazy evaluation to handle deprecaition
 
     @staticmethod
     @_deprecate_positional_args


### PR DESCRIPTION
Fixes scikit-learn#18186

This PR further parallelizes the imputation algorithm of sklearn.impute.KNNImputer by copying the method in which chunks were parallelized and implementing the same for sliced and columns. Also added an n_jobs parameter KNNImputer to so the user can manipulate the number of effective jobs if they choose to.

The changes to the KNNImputer are fully backwards compatible as well!

Unit tests were added to impute/tests/test_knn.py, and a benchmarking test file was added impute/tests/test_time.py